### PR TITLE
Feature - Prevent common password

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Rules\PreventCommonPassword;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -33,7 +34,7 @@ class NewPasswordController extends Controller
         $request->validate([
             'token' => ['required'],
             'email' => ['required', 'email'],
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'password' => ['required', 'confirmed', Rules\Password::defaults(), new PreventCommonPassword],
         ]);
 
         // Here we will attempt to reset the user's password. If it is successful we

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Rules\PreventCommonPassword;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -32,7 +33,7 @@ class RegisteredUserController extends Controller
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'password' => ['required', 'confirmed', Rules\Password::defaults(), new PreventCommonPassword],
         ]);
 
         $user = User::create([

--- a/app/Rules/PreventCommonPassword.php
+++ b/app/Rules/PreventCommonPassword.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class PreventCommonPassword implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (in_array(strtolower($value), $this->commonPasswords())) {
+            $fail('The chosen password is not strong enough. Try again with a more secure string.');
+        }
+    }
+
+    /**
+     * Returns an array of commonly used weak passwords.
+     * These are used to validate against in the validate method.
+     */
+    private function commonPasswords(): array
+    {
+        return [
+            'picture1',
+            'password',
+            'password1',
+            '12345678',
+            '111111',
+            '123123',
+            '12345',
+            '1234567890',
+            'senha',
+            '1234567',
+            'qwerty',
+            'abc123',
+            'Million2',
+            'OOOOOO',
+            '1234',
+            'iloveyou',
+            'aaron431',
+            'qqww1122',
+            '123',
+            'omgpop',
+            '123321',
+            '654321',
+            '123456789',
+            'qwerty123',
+            '1q2w3e4r',
+            'admin',
+            'qwertyuiop',
+            '555555',
+            'lovely',
+            '7777777',
+            'welcome',
+            '888888',
+            'princess',
+            'dragon',
+            '123qwe',
+            'sunshine',
+            '666666',
+            'football',
+            'monkey',
+            '!@#$%^&*',
+            'charlie',
+            'aa123456',
+            'donald',
+        ];
+    }
+}

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -67,8 +67,8 @@ class PasswordResetTest extends TestCase
             $response = $this->post('/reset-password', [
                 'token' => $notification->token,
                 'email' => $user->email,
-                'password' => 'password',
-                'password_confirmation' => 'password',
+                'password' => 'p@ssword',
+                'password_confirmation' => 'p@ssword',
             ]);
 
             $response

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -21,8 +21,8 @@ class RegistrationTest extends TestCase
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'password' => 'password',
-            'password_confirmation' => 'password',
+            'password' => 'p@ssword',
+            'password_confirmation' => 'p@ssword',
         ]);
 
         $this->assertAuthenticated();


### PR DESCRIPTION
## Summary by Sourcery

Enforce a stronger password policy by disallowing common weak passwords during user registration and password reset

New Features:
- Introduce PreventCommonPassword validation rule to reject a list of known weak passwords

Enhancements:
- Apply PreventCommonPassword rule in registration and password reset controllers to strengthen password requirements